### PR TITLE
chore: update cache actions to v5

### DIFF
--- a/.github/workflows/update-adobe-downloader.yml
+++ b/.github/workflows/update-adobe-downloader.yml
@@ -31,7 +31,7 @@ jobs:
       # 只缓存下载的 DMG 文件，避免重复下载相同版本
       # 使用 github.sha 作为缓存键，确保每次提交的缓存独立
       - name: Restore download cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         id: download-cache
         with:
           path: /tmp/cask-downloads/*.dmg
@@ -126,7 +126,7 @@ jobs:
           always() && 
           steps.download-cache.outputs.cache-hit != 'true' &&
           steps.check.outputs.update_needed == 'true'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: /tmp/cask-downloads/*.dmg
           key: ${{ steps.download-cache.outputs.cache-primary-key }}

--- a/.github/workflows/update-aliyundrive.yml
+++ b/.github/workflows/update-aliyundrive.yml
@@ -31,7 +31,7 @@ jobs:
       # 只缓存下载的 DMG 文件，避免重复下载相同版本
       # 使用 github.sha 作为缓存键，确保每次提交的缓存独立
       - name: Restore download cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         id: download-cache
         with:
           path: /tmp/cask-downloads/*.dmg
@@ -266,7 +266,7 @@ jobs:
           always() && 
           steps.download-cache.outputs.cache-hit != 'true' &&
           steps.check.outputs.update_needed == 'true'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: /tmp/cask-downloads/*.dmg
           key: ${{ steps.download-cache.outputs.cache-primary-key }}

--- a/.github/workflows/update-catalyst-browse.yml
+++ b/.github/workflows/update-catalyst-browse.yml
@@ -31,7 +31,7 @@ jobs:
       # 只缓存下载的 DMG 文件，避免重复下载相同版本
       # 使用 github.sha 作为缓存键，确保每次提交的缓存独立
       - name: Restore download cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         id: download-cache
         with:
           path: /tmp/cask-downloads/*.dmg
@@ -186,7 +186,7 @@ jobs:
           always() && 
           steps.download-cache.outputs.cache-hit != 'true' &&
           steps.check.outputs.update_needed == 'true'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: /tmp/cask-downloads/*.dmg
           key: ${{ steps.download-cache.outputs.cache-primary-key }}

--- a/.github/workflows/update-eudic.yml
+++ b/.github/workflows/update-eudic.yml
@@ -31,7 +31,7 @@ jobs:
       # 只缓存下载的 DMG 文件，避免重复下载相同版本
       # 使用 github.sha 作为缓存键，确保每次提交的缓存独立
       - name: Restore download cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         id: download-cache
         with:
           path: /tmp/cask-downloads/*.dmg
@@ -134,7 +134,7 @@ jobs:
           always() && 
           steps.download-cache.outputs.cache-hit != 'true' &&
           steps.check.outputs.update_needed == 'true'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: /tmp/cask-downloads/*.dmg
           key: ${{ steps.download-cache.outputs.cache-primary-key }}

--- a/.github/workflows/update-futu-niuniu.yml
+++ b/.github/workflows/update-futu-niuniu.yml
@@ -31,7 +31,7 @@ jobs:
       # 只缓存下载的 DMG 文件，避免重复下载相同版本
       # 使用 github.sha 作为缓存键，确保每次提交的缓存独立
       - name: Restore download cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         id: download-cache
         with:
           path: /tmp/cask-downloads/*.dmg
@@ -129,7 +129,7 @@ jobs:
           always() && 
           steps.download-cache.outputs.cache-hit != 'true' &&
           steps.check.outputs.update_needed == 'true'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: /tmp/cask-downloads/*.dmg
           key: ${{ steps.download-cache.outputs.cache-primary-key }}

--- a/.github/workflows/update-longbridge-pro.yml
+++ b/.github/workflows/update-longbridge-pro.yml
@@ -27,7 +27,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Restore download cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         id: download-cache
         with:
           path: /tmp/cask-downloads/longbridge-pro-*.dmg
@@ -122,7 +122,7 @@ jobs:
           always() &&
           steps.download-cache.outputs.cache-hit != 'true' &&
           steps.check.outputs.update_needed == 'true'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: /tmp/cask-downloads/longbridge-pro-*.dmg
           key: ${{ steps.download-cache.outputs.cache-primary-key }}

--- a/.github/workflows/update-quick-outline.yml
+++ b/.github/workflows/update-quick-outline.yml
@@ -27,7 +27,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Restore download cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         id: download-cache
         with:
           path: /tmp/cask-downloads/*.dmg
@@ -117,7 +117,7 @@ jobs:
           always() &&
           steps.download-cache.outputs.cache-hit != 'true' &&
           steps.check.outputs.update_needed == 'true'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: /tmp/cask-downloads/*.dmg
           key: ${{ steps.download-cache.outputs.cache-primary-key }}


### PR DESCRIPTION
## Summary
- Update all workflow cache restore/save steps from actions/cache v4 to v5.
- Move cache actions onto the Node 24 runtime to avoid Node 20 deprecation warnings.

## Verification
- `git diff --check`
- Confirmed no `actions/cache/restore@v4` or `actions/cache/save@v4` references remain.
- Confirmed 14 `actions/cache/*@v5` references across 7 workflows.

Note: `actionlint` is not installed locally, so workflow linting was not run here.