### PR TITLE
fix(ci): fail update workflows on errors

### DIFF
--- a/.github/workflows/update-adobe-downloader.yml
+++ b/.github/workflows/update-adobe-downloader.yml
@@ -54,9 +54,8 @@ jobs:
           TAG=$(printf "%s" "$json" | sed -n 's/.*"tag_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -n1)
 
           if [[ -z "${TAG:-}" ]]; then
-            echo "::warning::Failed to parse latest GitHub tag, skipping."
-            echo "update_needed=false" >> "$GITHUB_OUTPUT"
-            exit 0
+            echo "::error::Failed to parse latest GitHub tag."
+            exit 1
           fi
 
           echo "Latest tag: $TAG"

--- a/.github/workflows/update-adobe-downloader.yml
+++ b/.github/workflows/update-adobe-downloader.yml
@@ -41,7 +41,6 @@ jobs:
 
       - name: Check new version
         id: check
-        continue-on-error: true # 允许失败但不终止整个工作流
         shell: bash
         run: |
           set -euo pipefail

--- a/.github/workflows/update-aliyundrive.yml
+++ b/.github/workflows/update-aliyundrive.yml
@@ -147,9 +147,8 @@ jobs:
           fi
 
           if [[ -z "${NEW_VERSION:-}" ]]; then
-            echo "::warning::Failed to parse latest version, skipping."
-            echo "update_needed=false" >> "$GITHUB_OUTPUT"
-            exit 0
+            echo "::error::Failed to determine latest version."
+            exit 1
           fi
 
           echo "Latest version: $NEW_VERSION"

--- a/.github/workflows/update-aliyundrive.yml
+++ b/.github/workflows/update-aliyundrive.yml
@@ -41,7 +41,6 @@ jobs:
 
       - name: Check new version
         id: check
-        continue-on-error: true # 允许失败但不终止整个工作流
         shell: bash
         run: |
           set -euo pipefail

--- a/.github/workflows/update-catalyst-browse.yml
+++ b/.github/workflows/update-catalyst-browse.yml
@@ -41,7 +41,6 @@ jobs:
 
       - name: Check new version
         id: check
-        continue-on-error: true # 允许失败但不终止整个工作流
         shell: bash
         run: |
           set -euo pipefail

--- a/.github/workflows/update-eudic.yml
+++ b/.github/workflows/update-eudic.yml
@@ -41,7 +41,6 @@ jobs:
 
       - name: Check new version
         id: check
-        continue-on-error: true # 允许失败但不终止整个工作流
         shell: bash
         run: |
           set -euo pipefail

--- a/.github/workflows/update-eudic.yml
+++ b/.github/workflows/update-eudic.yml
@@ -56,9 +56,8 @@ jobs:
           BUILD=$(printf "%s" "$feed" | sed -nE 's/.*sparkle:version="([^"]+)".*/\1/p' | head -n1)
 
           if [[ -z "${SHORT:-}" || -z "${BUILD:-}" ]]; then
-            echo "::warning::Failed to parse Eudic version, skipping."
-            echo "update_needed=false" >> "$GITHUB_OUTPUT"
-            exit 0
+            echo "::error::Failed to parse Eudic version."
+            exit 1
           fi
 
           NEW_VERSION="$SHORT,$BUILD"

--- a/.github/workflows/update-futu-niuniu.yml
+++ b/.github/workflows/update-futu-niuniu.yml
@@ -176,9 +176,8 @@ jobs:
           fi
 
           if [[ -z "${NEW_VERSION:-}" ]]; then
-            echo "::warning::Failed to find a newer Futu version, skipping."
-            echo "update_needed=false" >> "$GITHUB_OUTPUT"
-            exit 0
+            echo "::error::Failed to determine latest Futu version."
+            exit 1
           fi
 
           echo "Latest version: $NEW_VERSION"

--- a/.github/workflows/update-futu-niuniu.yml
+++ b/.github/workflows/update-futu-niuniu.yml
@@ -47,7 +47,6 @@ jobs:
 
       - name: Check new version
         id: check
-        continue-on-error: true
         shell: bash
         run: |
           set -euo pipefail

--- a/.github/workflows/update-longbridge-pro.yml
+++ b/.github/workflows/update-longbridge-pro.yml
@@ -37,7 +37,6 @@ jobs:
 
       - name: Check new version
         id: check
-        continue-on-error: true
         shell: bash
         run: |
           set -euo pipefail

--- a/.github/workflows/update-longbridge-pro.yml
+++ b/.github/workflows/update-longbridge-pro.yml
@@ -49,9 +49,8 @@ jobs:
           NEW_VERSION=$(printf "%s" "$page" | grep -E '^version:' | head -n1 | sed -E 's/version: *([0-9.]+)/\1/')
 
           if [[ -z "${NEW_VERSION:-}" ]]; then
-            echo "::warning::Failed to parse Longbridge Pro version, skipping."
-            echo "update_needed=false" >> "$GITHUB_OUTPUT"
-            exit 0
+            echo "::error::Failed to parse Longbridge Pro version."
+            exit 1
           fi
 
           echo "Latest version: $NEW_VERSION"

--- a/.github/workflows/update-quick-outline.yml
+++ b/.github/workflows/update-quick-outline.yml
@@ -37,7 +37,6 @@ jobs:
 
       - name: Check new version
         id: check
-        continue-on-error: true
         shell: bash
         run: |
           set -euo pipefail

--- a/.github/workflows/update-quick-outline.yml
+++ b/.github/workflows/update-quick-outline.yml
@@ -50,9 +50,8 @@ jobs:
           TAG=$(printf "%s" "$json" | sed -n 's/.*"tag_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -n1)
 
           if [[ -z "${TAG:-}" ]]; then
-            echo "::warning::Failed to parse latest GitHub tag, skipping."
-            echo "update_needed=false" >> "$GITHUB_OUTPUT"
-            exit 0
+            echo "::error::Failed to parse latest GitHub tag."
+            exit 1
           fi
 
           echo "Latest tag: $TAG"


### PR DESCRIPTION
## Summary

- Remove `continue-on-error: true` from all seven cask update workflows.
- Preserve the explicit `update_needed=false` path for successful no-update checks.

## Why

The version-check steps previously allowed network, parsing, download, and checksum failures to continue as successful-looking workflow runs. Failures now stop the job and remain visible in GitHub Actions, while the existing final status report still runs through `if: always()`.

## Validation

- `git diff --check`
- YAML parsing for all workflows and local actions
- Confirmed no remaining `continue-on-error` in `.github/workflows` or `.github/actions`
- Confirmed every update workflow retains an explicit skip output and final status report
