### PR TITLE
fix(longbridge-pro): use working appcast URL

### DIFF
--- a/.github/workflows/update-longbridge-pro.yml
+++ b/.github/workflows/update-longbridge-pro.yml
@@ -45,7 +45,7 @@ jobs:
           echo "::group::Checking for new version"
           echo "Current version: $CURRENT_VERSION"
 
-          page=$(curl -fsSL 'https://download.wbrks.com/longbridge-desktop/prod/latest-mac.yml') || page=""
+          page=$(curl -fsSL 'https://download.lbkrs.com/longbridge-desktop/prod/latest-mac.yml') || page=""
           NEW_VERSION=$(printf "%s" "$page" | grep -E '^version:' | head -n1 | sed -E 's/version: *([0-9.]+)/\1/')
 
           if [[ -z "${NEW_VERSION:-}" ]]; then
@@ -135,7 +135,7 @@ jobs:
           old_version: ${{ steps.check.outputs.old_version }}
           new_sha256_intel: ${{ steps.check.outputs.new_sha256_intel }}
           new_sha256_arm: ${{ steps.check.outputs.new_sha256_arm }}
-          download_url: "https://download.wbrks.com/longbridge-desktop/prod/latest-mac.yml"
+          download_url: "https://download.lbkrs.com/longbridge-desktop/prod/latest-mac.yml"
 
       - name: Final status report
         if: always()

--- a/Casks/longbridge-pro.rb
+++ b/Casks/longbridge-pro.rb
@@ -13,7 +13,7 @@ cask "longbridge-pro" do
   homepage "https://longbridge.com/desktop/zh-CN/"
 
   livecheck do
-    url "https://download.wbrks.com/longbridge-desktop/prod/latest-mac.yml"
+    url "https://download.lbkrs.com/longbridge-desktop/prod/latest-mac.yml"
     strategy :electron_builder
   end
 


### PR DESCRIPTION
## Summary

- Update the Longbridge Pro Cask livecheck URL to the working `download.lbkrs.com` Electron Builder appcast.
- Update the scheduled updater and commit metadata to use the same source.

## Why

The Cask download URL already uses `download.lbkrs.com`, while the livecheck and updater still referenced the old `download.wbrks.com` hostname. The `lbkrs.com` appcast serves the current version and keeps version detection aligned with the download source.

## Validation

- `ruby -c Casks/longbridge-pro.rb`
- YAML parsing of `.github/workflows/update-longbridge-pro.yml`
- `git diff --check`
- `brew style gz4zzxc/cask/longbridge-pro`
- `brew audit --cask --strict gz4zzxc/cask/longbridge-pro`
- `HOMEBREW_CURL_RETRIES=3 brew livecheck --cask --debug gz4zzxc/cask/longbridge-pro` (`2.38.7 ==> 2.38.7`)