### PR TITLE
fix(ci): surface commit failures

### DIFF
--- a/.github/actions/commit-update/action.yml
+++ b/.github/actions/commit-update/action.yml
@@ -229,10 +229,25 @@ runs:
           SHA256_MSG="- Updated SHA256 checksum (arm64)"
         fi
 
+        STAGED_DIFF_STATUS=0
+        git diff --cached --quiet || STAGED_DIFF_STATUS=$?
+        case "$STAGED_DIFF_STATUS" in
+          0)
+            echo "::notice::No changes to commit"
+            exit 0
+            ;;
+          1)
+            ;;
+          *)
+            echo "::error::Failed to inspect staged changes (git diff exited with $STAGED_DIFF_STATUS)"
+            exit "$STAGED_DIFF_STATUS"
+            ;;
+        esac
+
         git commit \
           -m "$COMMIT_MSG" \
           -m "- Updated version from ${OLD_VERSION} to ${NEW_VERSION}" \
           -m "$SHA256_MSG" \
           -m "- Updated README.md version table (display ${NEW_VERSION_DISPLAY})" \
-          -m "- Source: ${DOWNLOAD_URL}" || exit 0
+          -m "- Source: ${DOWNLOAD_URL}"
         git push


### PR DESCRIPTION
## Summary

- Treat an empty staged diff as an explicit successful no-op.
- Preserve failures from `git diff --cached` and `git commit` instead of converting them to success.

## Why

The shared `commit-update` action previously ended the commit command with `|| exit 0`. Any commit failure, including permission or repository-state errors, could therefore make the update workflow look successful while skipping the push.

## Validation

- YAML parsing for all workflows and composite actions
- Shell syntax check for the `Commit and push` run block
- `git diff --check`
- Confirmed no swallowed `git commit ... || exit 0` path remains